### PR TITLE
chore: fix pydantic version, allow python 3.10 too

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ```bash
 
-poetry install ai-engine-sdk
+poetry add ai-engine-sdk
 # or 
 pip install ai-engine-sdk
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ authors = ["Xavier <xavier.peiro@fetch.ai>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "~3.11"
-pydantic = "^2.7.3"
+python = ">=3.10,<3.13"
+pydantic = "^1.10.7"
 aiohttp = "^3.9.5"
 
 


### PR DESCRIPTION
## Proposed Changes

- Setting pydantic version to major version 1 because uagents library doesn't support pydantic major version 2.
- Allowing python 3.10
- fixing readme to contain the correct poetry command

## Linked Issues

_[if applicable, add links to issues resolved by this PR]_

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [x] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

  - [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guide
  - [x] Checks and tests pass locally

### If applicable

  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have checked that code coverage does not decrease
  - [ ] I have added/updated the documentation

## Further comments

_[if this is a relatively large or complex change, kick off a discussion by explaining why you chose the solution you did, what alternatives you considered, etc...]_
