### PR TITLE
Fix key to request personality when creating a session

### DIFF
--- a/ai_engine_sdk/api_models/api_models.py
+++ b/ai_engine_sdk/api_models/api_models.py
@@ -27,7 +27,7 @@ class ApiNewSessionRequest(BaseModel):
     email: str
     functionGroup: Optional[str] = None
     preferencesEnabled: bool
-    requestModel: str
+    requestedModel: str
 
 
 class ApiUserJsonMessage(ApiMessagePayload):

--- a/ai_engine_sdk/client.py
+++ b/ai_engine_sdk/client.py
@@ -544,7 +544,7 @@ class AiEngine:
             email=opts.get('email') if opts else "",
             functionGroup=function_group,
             preferencesEnabled=False,
-            requestModel=opts.get('model') if opts and 'model' in opts else DefaultModelId
+            requestedModel=opts.get('model') if opts and 'model' in opts else DefaultModelId
         )
         response = await make_api_request(
             api_base_url=self._api_base_url,


### PR DESCRIPTION
## Proposed Changes

This PR fixes a bug: the key to use a specific personality in the request payload for the API to create a session is currently set to `requestModel`, while it should be `requestedModel`. This causes the personality string that we pass to be silently ignored. You can see for example that passing `"next-gen"` will always start a session with the `"talkative-01"` personality.

## Linked Issues

n.a.

## Types of changes

- [x] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

  - [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guide
  - [x] Checks and tests pass locally

### If applicable

  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have checked that code coverage does not decrease
  - [ ] I have added/updated the documentation

## Further comments

n.a.